### PR TITLE
Changing syntax for including role based on app type

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,8 @@
 
 - include: cron.yml
   when: modcloth_app_type == "cron"
+  register: modcloth_app_type_cron
 
 - include: long-running.yml
   when: modcloth_app_type == "long-running"
+  register: modcloth_app_type_long_running

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,4 +14,8 @@
   when: modcloth_app_docker_repo != ""
   register: modcloth_app_pull_container
 
-- include: "{{ modcloth_app_type }}.yml"
+- include: cron.yml
+  when: modcloth_app_type == "cron"
+
+- include: long-running.yml
+  when: modcloth_app_type == "long-running"


### PR DESCRIPTION
I keep on getting test-related issues with the `include: "{{ modcloth_app_type }}.yml"` syntax
