### PR TITLE
Allow specification of arbtrary flags to `docker run` in templates

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,3 +34,6 @@ modcloth_app_upstart_conf_template: upstart.conf.j2
 # Template used for the file written to
 # /usr/local/bin/{{ modcloth_app_name }}-cron-wrapper
 modcloth_app_cron_wrapper_template: cron-wrapper.sh.j2
+
+# Addition arguments to pass to `docker run`
+modcloth_app_docker_args: []

--- a/example.yml
+++ b/example.yml
@@ -7,11 +7,15 @@
     modcloth_app_docker_command:
       sh -c "while true ; do date ; sleep 10 ; done"
     modcloth_app_docker_repo: busybox
+    modcloth_app_docker_args:
+    - '-v /foo/bar:/foo/bar'
     modcloth_app_env:
       FOO: bar
   - role: modcloth.app
     modcloth_app_name: modcloth-cron-app
     modcloth_app_type: cron
+    modcloth_app_docker_args:
+    - '-v /foo/bar:/foo/bar'
     modcloth_app_docker_command: date
     modcloth_app_docker_repo: busybox
     modcloth_app_env:

--- a/templates/cron-wrapper.sh.j2
+++ b/templates/cron-wrapper.sh.j2
@@ -8,6 +8,9 @@ docker rm -f {{ modcloth_app_name }} >/dev/null 2>&1 || true
 exec run-one docker run \
   --env-file /etc/default/{{ modcloth_app_name }} \
   --name {{ modcloth_app_name }} \
+  {% for dockeropt in modcloth_app_docker_args %}
+  {{ dockeropt }} \
+  {% endfor %}
   --rm \
   {{ modcloth_app_docker_repo }}:{{ modcloth_app_docker_tag }} \
   {{ modcloth_app_docker_command }} \

--- a/templates/upstart.conf.j2
+++ b/templates/upstart.conf.j2
@@ -17,6 +17,9 @@ script
     -p {{ modcloth_app_docker_port }}:{{ modcloth_app_docker_port }} \
     --env-file /etc/default/{{ modcloth_app_name }} \
     --name {{ modcloth_app_name }} \
+    {% for dockeropt in modcloth_app_docker_args %}
+    {{ dockeropt }} \
+    {% endfor %}
     --rm \
     {{ modcloth_app_docker_repo }}:{{ modcloth_app_docker_tag }} {{ modcloth_app_docker_command }}
 end script


### PR DESCRIPTION
To avoid having to duplicate the template locally just to add an
argument to `docker run`

Addresses #8
