### PR TITLE
Move run-one outside of cron wrapper

### DIFF
--- a/tasks/cron.yml
+++ b/tasks/cron.yml
@@ -15,6 +15,6 @@
     day={{ modcloth_app_cron_schedule.split()[2] }}
     month={{ modcloth_app_cron_schedule.split()[3] }}
     weekday={{ modcloth_app_cron_schedule.split()[4] }}
-    job=/usr/local/bin/{{ modcloth_app_name }}-cron-wrapper
+    job="run-one /usr/local/bin/{{ modcloth_app_name }}-cron-wrapper"
   when: modcloth_app_cron_wrapper_template != ""
   register: modcloth_app_create_cron_job

--- a/templates/cron-wrapper.sh.j2
+++ b/templates/cron-wrapper.sh.j2
@@ -5,7 +5,7 @@ set -e
 docker stop {{ modcloth_app_name }} >/dev/null 2>&1 || true
 docker rm -f {{ modcloth_app_name }} >/dev/null 2>&1 || true
 
-exec run-one docker run \
+exec docker run \
   --env-file /etc/default/{{ modcloth_app_name }} \
   --name {{ modcloth_app_name }} \
   {% for dockeropt in modcloth_app_docker_args %}


### PR DESCRIPTION
Otherwise it may kill running jobs first

Signed-off-by: Dan Buch d.buch@modcloth.com
