### PR TITLE
Adding additional docker run args

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ modcloth_app_docker_tag: latest
 
 # Proxy port for docker container, passed via `-p` to `docker run`
 modcloth_app_docker_port: 3000
+# Also valid:
+# modcloth_app_docker_port:
+# - { host: 3000, container: 80 }
+# - { host: 8080, container: 9292, ip: 127.0.0.1 }
+# - { container: 22, ip: 127.0.0.1 }
+# Invalid:
+# - { host: 22, ip: 127.0.0.1 }
 
 # Cron job schedule
 modcloth_app_cron_schedule: "* * * * *"

--- a/README.md
+++ b/README.md
@@ -75,7 +75,13 @@ modcloth_app_upstart_start_condition: ""
 # ensures the directory on the host will be created
 modcloth_app_docker_volumes: []
 # Example:
-# - { host: /var/lib/redis, container: /var/lib/redis, directory: true}
+# - { host: /var/lib/redis, container: /var/lib/redis, directory: true }
+
+# adds the --link option for `docker run` to the templates
+modcloth_app_docker_link: []
+# Example:
+# - { name: style-gallery, alias: style-gallery }
+# # note: alias, if not provided, defaults to the same value as name
 ```
 
 ## License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,13 @@ modcloth_app_docker_tag: latest
 
 # Proxy port for docker container, passed via `-p` to `docker run`
 modcloth_app_docker_port: 3000
+# Also valid:
+# modcloth_app_docker_port:
+# - { host: 3000, container: 80 }
+# - { host: 8080, container: 9292, ip: 127.0.0.1 }
+# - { container: 22, ip: 127.0.0.1 }
+# Invalid:
+# - { host: 22, ip: 127.0.0.1 }
 
 # Cron job schedule
 modcloth_app_cron_schedule: "* * * * *"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,4 +60,10 @@ modcloth_app_upstart_start_condition: ""
 # ensures the directory on the host will be created
 modcloth_app_docker_volumes: []
 # Example:
-# - { host: /var/lib/redis, container: /var/lib/redis, directory: true}
+# - { host: /var/lib/redis, container: /var/lib/redis, directory: true }
+
+# adds the --link option for `docker run` to the templates
+modcloth_app_docker_link: []
+# Example:
+# - { name: style-gallery, alias: style-gallery }
+# # note: alias, if not provided, defaults to the same value as name

--- a/templates/upstart.conf.j2
+++ b/templates/upstart.conf.j2
@@ -12,21 +12,28 @@ respawn limit 3 30
 script
   {% for volume in modcloth_app_docker_volumes -%}
   {% if volume.directory is defined and volume.directory %} mkdir -p {{ volume.host }} {% endif %}
-  {% endfor %}
+  {% endfor -%}
 
   docker stop {{ modcloth_app_name }} >/dev/null 2>&1 || true
   docker rm -f {{ modcloth_app_name }} >/dev/null 2>&1 || true
 
   docker run --rm \
+    {% if modcloth_app_docker_port is number -%}
     -p {{ modcloth_app_docker_port }}:{{ modcloth_app_docker_port }} \
+    {% elif modcloth_app_docker_port is iterable -%}
+    {% for port in modcloth_app_docker_port -%}
+    -p {{ port.ip | default("") }}{% if port.ip is defined %}:{% endif %}{{ port.host | default("") }}{% if port.host is defined %}:{% endif %}{{ port.container }} \
+    {% endfor -%}
+    {% endif -%}
     --hostname "$(hostname)" \
     --env-file /etc/default/{{ modcloth_app_name }} \
     --name {{ modcloth_app_name }} \
     {% for dockeropt in modcloth_app_docker_args -%}
     {{ dockeropt }} \
-    {% endfor %}
+    {% endfor -%}
     {% for volume in modcloth_app_docker_volumes -%}
     -v {{ volume.host }}:{{ volume.container }}:{{ volume.permissions | default("rw") }} \
-    {% endfor %}
+    {% endfor -%}
     {{ modcloth_app_docker_repo }}:{{ modcloth_app_docker_tag }} {{ modcloth_app_docker_command }}
+
 end script

--- a/templates/upstart.conf.j2
+++ b/templates/upstart.conf.j2
@@ -25,6 +25,9 @@ script
     -p {{ port.ip | default("") }}{% if port.ip is defined %}:{% endif %}{{ port.host | default("") }}{% if port.host is defined %}:{% endif %}{{ port.container }} \
     {% endfor -%}
     {% endif -%}
+    {% for link in modcloth_app_docker_link -%}
+    --link {{ link.name }}:{{ link.alias | default(link.name) }} \
+    {% endfor -%}
     --hostname "$(hostname)" \
     --env-file /etc/default/{{ modcloth_app_name }} \
     --name {{ modcloth_app_name }} \


### PR DESCRIPTION
Currently this role allows the user to specify arbitrary docker args via `modcloth_app_docker_args` - is that a syntax we want to continue to support?

This pull request adds:
- full docker port mapping syntax
- docker run `--link` option
