### PR TITLE
Optionally notify NewRelic during deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,28 @@ modcloth_app_cron_logrotate_template: cron-logrotate.j2
 # additional conditions on the upstart service
 modcloth_app_upstart_start_condition: ""
 
+# Name of the application in NewRelic (for deployment notifications)
+modcloth_app_new_relic_app_name: "[{{env}}] {{modcloth_app_name}}"
+
 # Template used for the file written to /etc/init/{{ modcloth_app_name }}.conf
 modcloth_app_upstart_conf_template: upstart.conf.j2
+
+# Whether to notify NewRelic of app deployments
+modcloth_app_notify_new_relic: false
+
+# External dependency variables
+
+# Github API token
+github_token: "{{ github_api_token | default('') }}"
+
+# HipChat API token
+hipchat_token: "{{ hipchat_api_token | default('') }}"
+
+# HipChat room id
+hipchat_room: "{{ hipchat_team_room | default('') }}"
+
+# NewRelic API token (for deployment notifications)
+new_relic_api_token: "{{ new_relic_api_token | default('') }}"
 ```
 
 ## License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,6 +71,12 @@ modcloth_app_upstart_conf_template: upstart.conf.j2
 # Name of the organism running the playbook
 modcloth_app_deployer: ""
 
+# Name of the application in NewRelic (for deployment notifications)
+modcloth_app_new_relic_app_name: "[{{env}}] {{modcloth_app_name}}"
+
+# Whether to notify NewRelic of app deployments
+modcloth_app_notify_new_relic: false
+
 # External dependency variables
 
 # Github API token
@@ -81,3 +87,6 @@ hipchat_token: "{{ hipchat_api_token | default('') }}"
 
 # HipChat room id
 hipchat_room: "{{ hipchat_team_room | default('') }}"
+
+# NewRelic API token (for deployment notifications)
+new_relic_api_token: "{{ new_relic_api_token | default('') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -64,3 +64,13 @@
     color: purple
   changed_when: False
   when: hipchat_token != "" and hipchat_room != ""
+
+- name: notify new relic deploy complete
+  sudo: false
+  newrelic_deployment:
+    token="{{new_relic_api_token}}"
+    app_name="{{modcloth_app_new_relic_app_name}}"
+    revision="{{modcloth_app_docker_tag}}"
+    user="{{modcloth_app_deployer}}"
+  when: modcloth_app_notify_new_relic|bool
+  ignore_errors: yes


### PR DESCRIPTION
Requires new_relic_api_token. Default to off.

Resolves #35 
