### PR TITLE
Ignore errors when notifying Hipchat

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,7 @@
     mode=0644
   changed_when: False
   when: hipchat_token != "" and hipchat_room != ""
+  ignore_errors: True
 
 - name: notify hipchat deploy started
   sudo: false
@@ -64,3 +65,4 @@
     color: purple
   changed_when: False
   when: hipchat_token != "" and hipchat_room != ""
+  ignore_errors: True


### PR DESCRIPTION
Will cause error output, but the play will continue.

Fixes #34 
