### PR TITLE
Adding optional healthcheck url for long-running tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ modcloth_app_notify_new_relic: false
 
 # Whether or not to ship logs using the modcloth.rsyslog-file role (see meta/main.yml)
 modcloth_app_ship_logs: true
+
+# enable healthchecking after a restart
+modcloth_app_healthcheck_enabled: false
+
+# defaults for the healthcheck url
+modcloth_app_healthcheck_scheme: "http"
+modcloth_app_healthcheck_port: "80"
+modcloth_app_healthcheck_path: "heartbeat"
+modcloth_app_healthcheck_host: "{{ ansible_fqdn }}"
+modcloth_app_healthcheck_url: "{{ modcloth_app_healthcheck_scheme }}://{{ modcloth_app_healthcheck_host }}:{{ modcloth_app_healthcheck_port }}/{{ modcloth_app_healthcheck_path }}"
+modcloth_app_healthcheck_timeout: 1
+modcloth_app_healthcheck_delay: 1
+modcloth_app_healthcheck_retries: 30
 ```
 
 ## External Dependency Variables

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ modcloth_app_healthcheck_host: "{{ ansible_fqdn }}"
 modcloth_app_healthcheck_url: "{{ modcloth_app_healthcheck_scheme }}://{{ modcloth_app_healthcheck_host }}:{{ modcloth_app_healthcheck_port }}/{{ modcloth_app_healthcheck_path }}"
 modcloth_app_healthcheck_timeout: 1
 modcloth_app_healthcheck_delay: 1
-modcloth_app_healthcheck_retries: 30
+# modcloth_app_healthcheck_retries: 30 # currently not configurable due to https://github.com/ansible/ansible/issues/5865
 ```
 
 ## External Dependency Variables

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,6 +84,19 @@ modcloth_app_notify_new_relic: false
 # Whether or not to ship logs using the modcloth.rsyslog-file role (see meta/main.yml)
 modcloth_app_ship_logs: true
 
+# enable healthchecking after a restart
+modcloth_app_healthcheck_enabled: false
+
+# defaults for the healthcheck url
+modcloth_app_healthcheck_scheme: "http"
+modcloth_app_healthcheck_port: "80"
+modcloth_app_healthcheck_path: "heartbeat"
+modcloth_app_healthcheck_host: "{{ ansible_fqdn }}"
+modcloth_app_healthcheck_url: "{{ modcloth_app_healthcheck_scheme }}://{{ modcloth_app_healthcheck_host }}:{{ modcloth_app_healthcheck_port }}/{{ modcloth_app_healthcheck_path }}"
+modcloth_app_healthcheck_timeout: 1
+modcloth_app_healthcheck_delay: 1
+modcloth_app_healthcheck_retries: 30
+
 # External dependency variables
 
 # NewRelic API token (for deployment notifications)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -95,7 +95,7 @@ modcloth_app_healthcheck_host: "{{ ansible_fqdn }}"
 modcloth_app_healthcheck_url: "{{ modcloth_app_healthcheck_scheme }}://{{ modcloth_app_healthcheck_host }}:{{ modcloth_app_healthcheck_port }}/{{ modcloth_app_healthcheck_path }}"
 modcloth_app_healthcheck_timeout: 1
 modcloth_app_healthcheck_delay: 1
-modcloth_app_healthcheck_retries: 30
+# modcloth_app_healthcheck_retries: 30 # currently not configurable due to https://github.com/ansible/ansible/issues/5865
 
 # External dependency variables
 

--- a/tasks/long-running.yml
+++ b/tasks/long-running.yml
@@ -15,3 +15,5 @@
 
 - name: start app
   service: name={{ modcloth_app_name }} state=started
+
+- include: wait-healthcheck.yml

--- a/tasks/wait-healthcheck.yml
+++ b/tasks/wait-healthcheck.yml
@@ -8,7 +8,7 @@
     url: "{{ modcloth_app_healthcheck_url }}"
     timeout: "{{ modcloth_app_healthcheck_timeout }}"
   register: result
-  retries: "{{ modcloth_app_healthcheck_retries }}"
-  delay: "{{ modcloth_app_healthcheck_delay }}"
-  until: result.status < 400 and result.status >= 200
+  retries: 30 # currently not configurable due to https://github.com/ansible/ansible/issues/5865
+  delay:  "{{ modcloth_app_healthcheck_delay|int }}"
+  until: result.status is defined and result.status < 400 and result.status >= 200
   when: modcloth_app_healthcheck_enabled|bool

--- a/tasks/wait-healthcheck.yml
+++ b/tasks/wait-healthcheck.yml
@@ -1,0 +1,14 @@
+---
+- name: install pip package required for uri module
+  pip: name=httplib2 state=present
+  when: modcloth_app_healthcheck_enabled|bool
+
+- name: await healthy
+  uri:
+    url: "{{ modcloth_app_healthcheck_url }}"
+    timeout: "{{ modcloth_app_healthcheck_timeout }}"
+  register: result
+  retries: "{{ modcloth_app_healthcheck_retries }}"
+  delay: "{{ modcloth_app_healthcheck_delay }}"
+  until: result.status < 400 and result.status >= 200
+  when: modcloth_app_healthcheck_enabled|bool


### PR DESCRIPTION
If enabled, after restarting the container, ansible will wait for a healthcheck url to return a status code >= 200 and < 400

/cc @jszwedko @alexschlessinger 
